### PR TITLE
Extend minikube start command to accept windows os version flag 

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1304,8 +1304,7 @@ func validateFlags(cmd *cobra.Command, drvName string) { //nolint:gocyclo
 	}
 
 	if cmd.Flags().Changed(windowsNodeVersion) {
-		err := validateWindowsOSVersion(viper.GetString(windowsNodeVersion))
-		if err != nil {
+		if err := validateWindowsOSVersion(viper.GetString(windowsNodeVersion)); err != nil {
 			exit.Message(reason.Usage, "{{.err}}", out.V{"err": err})
 		}
 	}
@@ -1435,22 +1434,11 @@ func validateDiskSize(diskSize string) error {
 func validateWindowsOSVersion(osVersion string) error {
 	validOptions := node.ValidWindowsOSVersions()
 
-	if osVersion == constants.DefaultWindowsNodeVersion {
+	if validOptions[osVersion] {
 		return nil
 	}
 
-	var validOSVersion bool
-	for _, option := range validOptions {
-		if osVersion == option {
-			validOSVersion = true
-		}
-	}
-
-	if !validOSVersion {
-		return errors.Errorf("Invalid Windows Server OS Version: %s. Valid OS version are: %s", osVersion, node.ValidWindowsOSVersions())
-	}
-
-	return nil
+	return errors.Errorf("Invalid Windows Server OS Version: %s. Valid OS version are: %s", osVersion, maps.Keys(validOptions))
 }
 
 // validateRuntime validates the supplied runtime

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1303,6 +1303,13 @@ func validateFlags(cmd *cobra.Command, drvName string) { //nolint:gocyclo
 		validateCNI(cmd, viper.GetString(containerRuntime))
 	}
 
+	if cmd.Flags().Changed(windowsNodeVersion) {
+		err := validateWindowsOSVersion(viper.GetString(windowsNodeVersion))
+		if err != nil {
+			exit.Message(reason.Usage, "{{.err}}", out.V{"err": err})
+		}
+	}
+
 	if cmd.Flags().Changed(staticIP) {
 		if err := validateStaticIP(viper.GetString(staticIP), drvName, viper.GetString(subnet)); err != nil {
 			exit.Message(reason.Usage, "{{.err}}", out.V{"err": err})
@@ -1421,6 +1428,28 @@ func validateDiskSize(diskSize string) error {
 	if diskSizeMB < minimumDiskSize {
 		return errors.Errorf("Requested disk size %v is less than minimum of %v", diskSizeMB, minimumDiskSize)
 	}
+	return nil
+}
+
+// validateWindowsOSVersion validates the supplied window server os version
+func validateWindowsOSVersion(osVersion string) error {
+	validOptions := node.ValidWindowsOSVersions()
+
+	if osVersion == constants.DefaultWindowsNodeVersion {
+		return nil
+	}
+
+	var validOSVersion bool
+	for _, option := range validOptions {
+		if osVersion == option {
+			validOSVersion = true
+		}
+	}
+
+	if !validOSVersion {
+		return errors.Errorf("Invalid Windows Server OS Version: %s. Valid OS version are: %s", osVersion, node.ValidWindowsOSVersions())
+	}
+
 	return nil
 }
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -45,6 +45,7 @@ import (
 	gopshost "github.com/shirou/gopsutil/v3/host"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/exp/maps"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 	"k8s.io/minikube/pkg/minikube/command"

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -144,6 +144,7 @@ const (
 	staticIP                = "static-ip"
 	gpus                    = "gpus"
 	autoPauseInterval       = "auto-pause-interval"
+	windowsNodeVersion      = "windows-node-version"
 )
 
 var (
@@ -208,6 +209,8 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(staticIP, "", "Set a static IP for the minikube cluster, the IP must be: private, IPv4, and the last octet must be between 2 and 254, for example 192.168.200.200 (Docker and Podman drivers only)")
 	startCmd.Flags().StringP(gpus, "g", "", "Allow pods to use your NVIDIA GPUs. Options include: [all,nvidia] (Docker driver with Docker container-runtime only)")
 	startCmd.Flags().Duration(autoPauseInterval, time.Minute*1, "Duration of inactivity before the minikube VM is paused (default 1m0s)")
+	startCmd.Flags().String(windowsNodeVersion, constants.DefaultWindowsNodeVersion, "The version of Windows to use for the windows node on a multi-node cluster (e.g., 2019, 2022). Defaults to Windows Server 2022.")
+
 }
 
 // initKubernetesFlags inits the commandline flags for Kubernetes related options

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -209,7 +209,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(staticIP, "", "Set a static IP for the minikube cluster, the IP must be: private, IPv4, and the last octet must be between 2 and 254, for example 192.168.200.200 (Docker and Podman drivers only)")
 	startCmd.Flags().StringP(gpus, "g", "", "Allow pods to use your NVIDIA GPUs. Options include: [all,nvidia] (Docker driver with Docker container-runtime only)")
 	startCmd.Flags().Duration(autoPauseInterval, time.Minute*1, "Duration of inactivity before the minikube VM is paused (default 1m0s)")
-	startCmd.Flags().String(windowsNodeVersion, constants.DefaultWindowsNodeVersion, "The version of Windows to use for the windows node on a multi-node cluster (e.g., 2019, 2022). Defaults to Windows Server 2022")
+	startCmd.Flags().String(windowsNodeVersion, constants.DefaultWindowsNodeVersion, "The version of Windows to use for the Windows node on a multi-node cluster (e.g., 2019, 2022). Defaults to Windows Server 2022")
 
 }
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -209,7 +209,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(staticIP, "", "Set a static IP for the minikube cluster, the IP must be: private, IPv4, and the last octet must be between 2 and 254, for example 192.168.200.200 (Docker and Podman drivers only)")
 	startCmd.Flags().StringP(gpus, "g", "", "Allow pods to use your NVIDIA GPUs. Options include: [all,nvidia] (Docker driver with Docker container-runtime only)")
 	startCmd.Flags().Duration(autoPauseInterval, time.Minute*1, "Duration of inactivity before the minikube VM is paused (default 1m0s)")
-	startCmd.Flags().String(windowsNodeVersion, constants.DefaultWindowsNodeVersion, "The version of Windows to use for the windows node on a multi-node cluster (e.g., 2019, 2022). Defaults to Windows Server 2022.")
+	startCmd.Flags().String(windowsNodeVersion, constants.DefaultWindowsNodeVersion, "The version of Windows to use for the windows node on a multi-node cluster (e.g., 2019, 2022). Defaults to Windows Server 2022")
 
 }
 

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -492,7 +492,7 @@ func TestValidateWindowsOSVersion(t *testing.T) {
 		},
 		{
 			osVersion: "2023",
-			errorMsg:  "Invalid Windows OS Version: 2023. Valid versions are: 2019, 2022",
+			errorMsg:  "Invalid Windows Server OS Version: 2023. Valid OS version are: [2019 2022]",
 		},
 	}
 	for _, test := range tests {

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -477,6 +477,38 @@ func TestValidateRuntime(t *testing.T) {
 	}
 }
 
+func TestValidateWindowsOSVersion(t *testing.T) {
+	var tests = []struct {
+		osVersion string
+		errorMsg  string
+	}{
+		{
+			osVersion: "2019",
+			errorMsg:  "",
+		},
+		{
+			osVersion: "2022",
+			errorMsg:  "",
+		},
+		{
+			osVersion: "2023",
+			errorMsg:  "Invalid Windows OS Version: 2023. Valid versions are: 2019, 2022",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.osVersion, func(t *testing.T) {
+			got := validateWindowsOSVersion(test.osVersion)
+			gotError := ""
+			if got != nil {
+				gotError = got.Error()
+			}
+			if gotError != test.errorMsg {
+				t.Errorf("ValidateWindowsOSVersion(osVersion=%v): got %v, expected %v", test.osVersion, got, test.errorMsg)
+			}
+		})
+	}
+}
+
 func TestIsTwoDigitSemver(t *testing.T) {
 	var tcs = []struct {
 		desc     string

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -480,30 +480,24 @@ func TestValidateRuntime(t *testing.T) {
 func TestValidateWindowsOSVersion(t *testing.T) {
 	var tests = []struct {
 		osVersion string
-		errorMsg  string
+		wantedError  error
 	}{
 		{
 			osVersion: "2019",
-			errorMsg:  "",
 		},
 		{
 			osVersion: "2022",
-			errorMsg:  "",
 		},
 		{
 			osVersion: "2023",
-			errorMsg:  "Invalid Windows Server OS Version: 2023. Valid OS version are: [2019 2022]",
+			wantedError:  errors.New("Invalid Windows Server OS Version: 2023. Valid OS version are: [2019 2022]"),
 		},
 	}
-	for _, test := range tests {
-		t.Run(test.osVersion, func(t *testing.T) {
-			got := validateWindowsOSVersion(test.osVersion)
-			gotError := ""
-			if got != nil {
-				gotError = got.Error()
-			}
-			if gotError != test.errorMsg {
-				t.Errorf("ValidateWindowsOSVersion(osVersion=%v): got %v, expected %v", test.osVersion, got, test.errorMsg)
+	for _, tc := range tests {
+		t.Run(tc.osVersion, func(t *testing.T) {
+			got := validateWindowsOSVersion(tc.osVersion)
+			if got != tc.wantedError {
+				t.Errorf("ValidateWindowsOSVersion(osVersion=%s): got %v, expected %v", test.osVersion, got, tc.wantedError)
 			}
 		})
 	}

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -480,24 +480,30 @@ func TestValidateRuntime(t *testing.T) {
 func TestValidateWindowsOSVersion(t *testing.T) {
 	var tests = []struct {
 		osVersion string
-		wantedError  error
+		errorMsg  string
 	}{
 		{
 			osVersion: "2019",
+			errorMsg:  "",
 		},
 		{
 			osVersion: "2022",
+			errorMsg:  "",
 		},
 		{
 			osVersion: "2023",
-			wantedError:  errors.New("Invalid Windows Server OS Version: 2023. Valid OS version are: [2019 2022]"),
+			errorMsg:  "Invalid Windows Server OS Version: 2023. Valid OS version are: [2019 2022]",
 		},
 	}
-	for _, tc := range tests {
-		t.Run(tc.osVersion, func(t *testing.T) {
-			got := validateWindowsOSVersion(tc.osVersion)
-			if got != tc.wantedError {
-				t.Errorf("ValidateWindowsOSVersion(osVersion=%s): got %v, expected %v", test.osVersion, got, tc.wantedError)
+	for _, test := range tests {
+		t.Run(test.osVersion, func(t *testing.T) {
+			got := validateWindowsOSVersion(test.osVersion)
+			gotError := ""
+			if got != nil {
+				gotError = got.Error()
+			}
+			if gotError != test.errorMsg {
+				t.Errorf("ValidateWindowsOSVersion(osVersion=%v): got %v, expected %v", test.osVersion, got, test.errorMsg)
 			}
 		})
 	}

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -163,6 +163,9 @@ const (
 
 	// Mirror CN
 	AliyunMirror = "registry.cn-hangzhou.aliyuncs.com/google_containers"
+
+	// DefaultWindowsNodeVersion is the default version of Windows node
+	DefaultWindowsNodeVersion = "2022"
 )
 
 var (

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -973,7 +973,7 @@ To see benchmarks checkout https://minikube.sigs.k8s.io/docs/benchmarks/cpuusage
 	}
 }
 
-// ValidWindowsOS lists the supported Windows OS versions
-func ValidWindowsOSVersions() []string {
-	return []string{"2019", "2022"}
+// ValidWindowsOSVersions lists the supported Windows OS versions
+func ValidWindowsOSVersions() map[string]bool {
+	return map[string]bool{"2019": true, "2022": true}
 }

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -972,3 +972,8 @@ To see benchmarks checkout https://minikube.sigs.k8s.io/docs/benchmarks/cpuusage
 `, out.V{"drivers": altDriverList.String()})
 	}
 }
+
+// ValidWindowsOS lists the supported Windows OS versions
+func ValidWindowsOSVersions() []string {
+	return []string{"2019", "2022"}
+}

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -122,6 +122,7 @@ minikube start [flags]
       --vm-driver driver                  DEPRECATED, use driver instead.
       --wait strings                      comma separated list of Kubernetes components to verify and wait for after starting a cluster. defaults to "apiserver,system_pods", available options: "apiserver,system_pods,default_sa,apps_running,node_ready,kubelet" . other acceptable values are 'all' or 'none', 'true' and 'false' (default [apiserver,system_pods])
       --wait-timeout duration             max time to wait per Kubernetes or host to be healthy. (default 6m0s)
+      --windows-node-version string       The version of Windows to use for the windows node on a multi-node cluster (e.g., 2019, 2022). Defaults to Windows Server 2022
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Extend the minikube start command to accept the `--windows-node-version` flag for windows node in multi-cluster os.


[Windows Node Support in minikube Proposal](https://github.com/kubernetes/minikube/pull/18707)